### PR TITLE
update: deflate to store

### DIFF
--- a/src/utils/zipper.ts
+++ b/src/utils/zipper.ts
@@ -63,8 +63,8 @@ export class Zipper extends Base {
 
     const options: JSZip.JSZipGeneratorOptions = {
       type: 'nodebuffer',
-      compression: 'DEFLATE',
-      compressionOptions: {level: 9},
+      compression: 'STORE',
+      //compressionOptions: {level: 9},
       platform: 'UNIX'
     };
 


### PR DESCRIPTION
The compression of `deflate` spends more than 1000 ms and `store` is less than 1000 ms.