### PR TITLE
Feat: implement `Topic.image` for browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,9 +273,10 @@ topic.marker(Object.assign({}, marker.smiley('cry'), {del: true}));
 
 You can use `.image()` to get `image key` back.
 
-However, you need to write image into manifest by `zip.updateManifestMetadata()`.
+However, you need to write image into manifest by `zip.updateManifestMetadata()` or `dumper.updateManifestMetadata()`.
 
 > [See image example](./example/example.image.js)
+> [See image in browser example](./example/example.image.browser.html)
 
 #### .summary(options) => Topic
 
@@ -383,6 +384,8 @@ Save components to the logic disk in the form of zip.
 
 The module of `Dumper` only works under browser.
 
+### Dumper methods
+
 #### .dumping() => Array<{filename: string, value: string}>
 
 Return an array of objects composed of file content.
@@ -392,6 +395,33 @@ you need to compress these files in the form of zip with the suffix `.xmind`.
 > **Important**
 > 
 > Don't include top level folders, otherwise the software can't extract files
+
+#### .updateManifestMetadata(key, content, creator) => Promise\<void\>
+
+Update manifest for image insertion.
+
+| Name | Type | Default | Required | Description |
+|:---- |:----:|:-------:|:--------:|:------------|
+| key | string | null | Y | The key only can get by topic.image() |
+| content | File \| Blob \| ArrayBuffer | null | Y | The data of image |
+| creator | FileCreator | | Y | specify how to save the file |
+
+where `FileCreator` is
+
+```typescript
+interface FileCreator {
+  /**
+   * hint that should create a folder-like structure, enter the folder if exists
+   * @param name Folder name
+   */
+  folder(name: string): Promise<void>
+  /**
+   * hint that should create a file-like object with `content`, update the file if exists
+   * @param name Filename
+   */
+  file(name: string, content: File | Blob | ArrayBuffer): Promise<void>
+}
+```
 
 ## Contributing
 Thank you for being interested in the SDK.

--- a/example/example.image.browser.html
+++ b/example/example.image.browser.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="../dist/xmind-sdk.bundle.js"></script>
+    <title>Example browser</title>
+  </head>
+
+  <body>
+    <label>
+      Insert Image:
+      <input type="file" accept="image/*" id="image-input" />
+    </label>
+
+    <script>
+      const input = document.getElementById("image-input");
+      input.addEventListener("change", (e) => {
+        if (!e.currentTarget.files || !e.currentTarget.files.length) {
+          return;
+        }
+
+        const [file] = e.currentTarget.files;
+
+        if (window.Workbook) {
+          const { Workbook, Topic, Dumper } = window;
+          const workbook = new Workbook();
+          const topic = new Topic({ sheet: workbook.createSheet("sheet-1") });
+          topic
+            .on()
+            .add({ title: "main topic 1" })
+            .add({ title: "main topic 2" });
+
+          const dumper = new Dumper({ workbook });
+
+          const imageKey = topic.image();
+          // work with the image, e.g. save the image to the storage
+          const storage = getStorage();
+          dumper
+            .updateManifestMetadata(imageKey, file, {
+              folder(name) {
+                return storage.folder(name);
+              },
+              file(name, content) {
+                return storage.file(name, content);
+              },
+            })
+            .then(() => {
+              const files = dumper.dumping();
+              console.log(files);
+
+              for (const file of files) {
+                console.log(file.filename, "\n", file.value);
+              }
+            });
+        }
+      });
+    </script>
+
+    <script>
+      // mock storage, not important
+      function getStorage() {
+        /** @type {Promise<IDBDatabase>} */
+        const dbReadyPromise = new Promise((resolve) => {
+          /** @type {IDBDatabase} */
+          let db;
+          const setupStore = () => {
+            return new Promise((resolve) => {
+              const resourcesStore = db
+                .transaction("resources", "readwrite")
+                .objectStore("resources");
+              resourcesStore.clear().addEventListener("success", () => {
+                console.log("[mock] store cleared");
+                resolve(db);
+              });
+            });
+          };
+
+          const openDbRequest = indexedDB.open("example", 1);
+          openDbRequest.addEventListener("error", () => {
+            console.error("[mock] error openning db");
+          });
+          openDbRequest.addEventListener("success", () => {
+            db = openDbRequest.result;
+            resolve(setupStore());
+          });
+          openDbRequest.addEventListener("upgradeneeded", (e) => {
+            db = e.target.result;
+            const resources = db.createObjectStore("resources", {
+              keyPath: "id",
+            });
+
+            resources.createIndex("id", "id", { unique: true });
+
+            resources.transaction.addEventListener("complete", () => {
+              resolve(setupStore());
+            });
+          });
+        });
+
+        const saveFile = (/** @type {IDBDatabase} */ db, { name, content }) => {
+          return Promise.resolve()
+            .then(() =>
+              content instanceof Blob ? content.arrayBuffer() : content
+            )
+            .then(
+              (resolvedContent) =>
+                new Promise((resolve) => {
+                  db.transaction("resources", "readwrite")
+                    .objectStore("resources")
+                    .put({ id: name, content: resolvedContent })
+                    .addEventListener("success", () => {
+                      console.log("[mock] file saved");
+                      resolve();
+                    });
+                })
+            );
+        };
+
+        const getDB = () => dbReadyPromise;
+
+        return {
+          file(name, content) {
+            return getDB().then((db) => saveFile(db, { name, content }));
+          },
+          folder(name) {
+            return getDB().then(() => {
+              console.log("[mock] move to resources");
+            });
+          },
+        };
+      }
+    </script>
+  </body>
+</html>

--- a/src/abstracts/topic.abstract.ts
+++ b/src/abstracts/topic.abstract.ts
@@ -43,8 +43,7 @@ export interface AbstractTopic {
    * @param {Object} options
    * @param {String} [options.width] - Image width
    * @param {String} [options.height] - image height
-   * @return {String} a file key that can be used for Zipper.updateManifestMetadata
-   * @supported For now, only Node.js runtime environment is allowed
+   * @return {String} a file key that can be used for `Zipper.updateManifestMetadata` and `Dumper.updateManifestMetadata`
    */
   image(options?: ImageOptions): string;
 

--- a/src/core/topic.ts
+++ b/src/core/topic.ts
@@ -5,7 +5,7 @@ import {
 import { SummaryOptions } from '../abstracts/summary.abstract';
 import { Summary } from './summary';
 import { Note } from './note';
-import { isEmpty, isObject, isRuntime, isString } from '../utils/common';
+import { isEmpty, isObject, isString } from '../utils/common';
 
 import * as Model from '../common/model';
 import * as Core from 'xmind-model';
@@ -88,11 +88,6 @@ export class Topic extends Base implements AbstractTopic {
   }
 
   public image(options?: ImageOptions): string {
-    /* istanbul ignore if */
-    if (!isRuntime()) {
-      throw new Error('Cannot run .image() in browser environment');
-    }
-
     const dir = `resources/${this.id}`;
     const params = Object.assign({}, {src: `xap:${dir}`}, options || {});
     this.parent().addImage(params);

--- a/src/utils/dumper.ts
+++ b/src/utils/dumper.ts
@@ -1,4 +1,5 @@
 import { Workbook } from '../core/workbook';
+import { PACKAGE_MAP } from '../common/constants';
 
 const XMLContents = `<?xml version="1.0" encoding="UTF-8" standalone="no"?><xmap-content xmlns="urn:xmind:xmap:xmlns:content:2.0" xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" modified-by="bruce" timestamp="1503058545540" version="2.0"><sheet id="7abtd0ssc7n4pi1nu6i7b6lsdh" modified-by="bruce" theme="0kdeemiijde6nuk97e4t0vpp54" timestamp="1503058545540"><topic id="1vr0lcte2og4t2sopiogvdmifc" modified-by="bruce" structure-class="org.xmind.ui.logic.right" timestamp="1503058545417"><title>Warning
 警告
@@ -6,25 +7,38 @@ Attention
 Warnung
 경고</title><children><topics type="attached"><topic id="71h1aip2t1o8vvm0a41nausaar" modified-by="bruce" timestamp="1503058545423"><title svg:width="500">This file can not be opened normally, please do not modify and save, otherwise the contents will be permanently lost！</title><children><topics type="attached"><topic id="428akmkh9a0tog6c91qj995qdl" modified-by="bruce" timestamp="1503058545427"><title>You can try using XMind 8 Update 3 or later version to open</title></topic></topics></children></topic><topic id="2kb87f8m38b3hnfhp450c7q35e" modified-by="bruce" timestamp="1503058545434"><title svg:width="500">该文件无法正常打开，请勿修改并保存，否则文件内容将会永久性丢失！</title><children><topics type="attached"><topic id="3m9hoo4a09n53ofl6fohdun99f" modified-by="bruce" timestamp="1503058545438"><title>你可以尝试使用 XMind 8 Update 3 或更新版本打开</title></topic></topics></children></topic><topic id="7r3r4617hvh931ot9obi595r8f" modified-by="bruce" timestamp="1503058545444"><title svg:width="500">該文件無法正常打開，請勿修改並保存，否則文件內容將會永久性丟失！</title><children><topics type="attached"><topic id="691pgka6gmgpgkacaa0h3f1hjb" modified-by="bruce" timestamp="1503058545448"><title>你可以嘗試使用 XMind 8 Update 3 或更新版本打開</title></topic></topics></children></topic><topic id="0f2e3rpkfahg4spg4nda946r0b" modified-by="bruce" timestamp="1503058545453"><title svg:width="500">この文書は正常に開かないので、修正して保存しないようにしてください。そうでないと、書類の内容が永久に失われます。！</title><children><topics type="attached"><topic id="4vuubta53ksc1falk46mevge0t" modified-by="bruce" timestamp="1503058545457"><title>XMind 8 Update 3 や更新版を使って開くこともできます</title></topic></topics></children></topic><topic id="70n9i4u3lb89sq9l1m1bs255j5" modified-by="bruce" timestamp="1503058545463"><title svg:width="500">Datei kann nicht richtig geöffnet werden. Bitte ändern Sie diese Datei nicht und speichern Sie sie, sonst wird die Datei endgültig gelöscht werden.</title><children><topics type="attached"><topic id="1qpc5ee298p2sqeqbinpca46b7" modified-by="bruce" timestamp="1503058545466"><title svg:width="500">Bitte versuchen Sie, diese Datei mit XMind 8 Update 3 oder später zu öffnen.</title></topic></topics></children></topic><topic id="4dmes10uc19pq7enu8sc4bmvif" modified-by="bruce" timestamp="1503058545473"><title svg:width="500">Ce fichier ne peut pas ouvert normalement, veuillez le rédiger et sauvegarder, sinon le fichier sera perdu en permanence. </title><children><topics type="attached"><topic id="5f0rivgubii2launodiln7sdkt" modified-by="bruce" timestamp="1503058545476"><title svg:width="500">Vous pouvez essayer d'ouvrir avec XMind 8 Update 3 ou avec une version plus récente.</title></topic></topics></children></topic><topic id="10pn1os1sgfsnqa8akabom5pej" modified-by="bruce" timestamp="1503058545481"><title svg:width="500">파일을 정상적으로 열 수 없으며, 수정 및 저장하지 마십시오. 그렇지 않으면 파일의 내용이 영구적으로 손실됩니다!</title><children><topics type="attached"><topic id="0l2nr0fq3em22rctapkj46ue58" modified-by="bruce" timestamp="1503058545484"><title svg:width="500">XMind 8 Update 3 또는 이후 버전을 사용하여</title></topic></topics></children></topic></topics></children><extensions><extension provider="org.xmind.ui.map.unbalanced"><content><right-number>-1</right-number></content></extension></extensions></topic><title>Sheet 1</title></sheet></xmap-content>`;
 
-const PACKAGE_MAP = {
-  MANIFEST: { NAME: 'manifest.json', TYPE: 'json' },
-  CONTENT_JSON: { NAME: 'content.json', TYPE: 'json'},
-  CONTENT_XML: { NAME: 'content.xml', TYPE: 'xml'},
-  METADATA: { NAME: 'metadata.json', TYPE: 'json'}
-};
-
 export interface DumperOptions {
   workbook: Workbook;
 }
 
+type FileContent = ArrayBuffer | File | Blob;
+
+export interface FileCreator {
+  /**
+   * hint that should enter a folder-like structure, create one if not exists
+   * @param name Folder name
+   */
+  folder(name: string): Promise<void>
+  /**
+   * hint that a file-like object should be created with the `content`, overrides if exists
+   * @param name Filename
+   */
+  file(name: string, content: FileContent): Promise<void>
+}
+
 export class Dumper {
   private workbook: Workbook;
+
+  private _manifest: Record<string, unknown>;
 
   constructor(protected options: DumperOptions = <DumperOptions>{}) {
     if (!(options.workbook instanceof Workbook)) {
       throw new Error('The instance of workbook is required');
     }
     this.workbook = options.workbook;
+    this._manifest = {
+      'file-entries': {'content.json': {}, 'metadata.json':{}}
+    };
   }
 
   /**
@@ -37,6 +51,21 @@ export class Dumper {
       .concat(this.xml)
       .concat(this.manifest)
       .concat(this.metadata);
+  }
+
+  /**
+   * @description Update manifest metadata
+   * @param { string } key - a string key
+   * @param { FileContent } content - file content
+   * @param { FileCreator } creator - specify how to save the file
+   * @return { Promise<void> } a promise that follows the promise returned by the method of `creator`, or rejects if the key is empty
+   */
+  public async updateManifestMetadata(key: string, content: FileContent, creator: FileCreator) {
+    if (!key) throw new Error('key is empty');
+    const [folderName, fileName] = key.split('/');
+    await creator.folder(folderName);
+    await creator.file(fileName, content);
+    this._manifest['file-entries'][key] = {};
   }
 
   private wrap(name: string, value: any) {
@@ -55,8 +84,7 @@ export class Dumper {
    * @description manifest.json
    */
   get manifest() {
-    const value = '{"file-entries":{"content.json":{},"metadata.json":{}}}';
-    return this.wrap(PACKAGE_MAP.MANIFEST.NAME, value);
+    return this.wrap(PACKAGE_MAP.MANIFEST.NAME, JSON.stringify(this._manifest));
   }
 
   /**

--- a/test/units/dumper.test.ts
+++ b/test/units/dumper.test.ts
@@ -1,6 +1,8 @@
-import { Workbook } from '../../src';
+import { Topic, Workbook } from '../../src';
 import { Dumper } from '../../src/utils/dumper';
 import { expect } from 'chai';
+
+const unreachable = () => { throw new Error('unreachable'); };
 
 describe('# Dumper Unit Test', () => {
 
@@ -15,6 +17,120 @@ describe('# Dumper Unit Test', () => {
     }
   });
 
+  it('should be able to update manifest', done => {
+    const workbook = new Workbook();
+    const sheet = workbook.createSheet('s1','r1');
+    const topic = new Topic({ sheet });
+    const imageKey1 = topic.image();
+    const imageKey2 = topic.image();
+    const dumper = new Dumper({workbook});
+
+    const mockImageData1 = new Uint8Array();
+    dumper.updateManifestMetadata(imageKey1, mockImageData1, {
+      file(name, content) {
+        expect(name).to.be.a('string');
+        expect(content).to.be.an('Uint8Array');
+        return Promise.resolve();
+      },
+      folder(name) {
+        expect(name).to.be.a('string');
+        return Promise.resolve();
+      }
+    })
+    .then(() => (
+      dumper.updateManifestMetadata(imageKey2, mockImageData1, {
+        file(name, content) {
+          expect(name).to.be.a('string');
+          expect(content).to.be.an('Uint8Array');
+          return Promise.resolve();
+        },
+        folder(name) {
+          expect(name).to.be.a('string');
+          return Promise.resolve();
+        }
+      })
+    ))
+    .then(() => {
+      const files = dumper.dumping();
+      expect(files).to.be.an('array');
+      expect(files.length).to.eq(4);
+      for (const obj of files) {
+        expect(obj).to.have.property('filename');
+        expect(obj).to.have.property('value').that.to.be.an('string');
+      }
+      const parsedManifest = JSON.parse(dumper.manifest.value)
+      expect(parsedManifest['file-entries']).to.have.ownProperty(imageKey1)
+      expect(parsedManifest['file-entries']).to.have.ownProperty(imageKey2)
+      done();
+    });
+  });
+
+  it('should fail if the key is empty when updating manifest', done => {
+    const workbook = new Workbook();
+    workbook.createSheet('s1','r1');
+    const invalidKey = '';
+    const dumper = new Dumper({workbook});
+
+    const mockImageData = new Uint8Array();
+    dumper.updateManifestMetadata(invalidKey, mockImageData, {
+      file(name, content) {
+        return unreachable();
+      },
+      folder(name) {
+        return unreachable();
+      }
+    })
+    .then(() => {
+      return unreachable();
+    })
+    .catch((e) => {
+      expect(e).to.be.an('error').with.property('message').include('key')
+      done()
+    })
+  });
+
+  it('should fail if creator failed to create file when updating manifest', done => {
+    const workbook = new Workbook();
+    const sheet = workbook.createSheet('s1','r1');
+    const topic = new Topic({ sheet })
+    const imageKey = topic.image()
+    const dumper = new Dumper({workbook});
+
+    const mockImageData = new Uint8Array();
+    dumper
+      .updateManifestMetadata(imageKey, mockImageData, {
+        file(name, content) {
+          return unreachable();
+        },
+        folder(name) {
+          throw new Error("create folder failed");
+        },
+      })
+      .then(() => {
+        return unreachable();
+      })
+      .catch((e) => {
+        expect(e).to.be.an("error").with.property("message").include("folder");
+      })
+      .then(() =>
+        dumper.updateManifestMetadata(imageKey, mockImageData, {
+          file(name, content) {
+            throw new Error("create file failed");
+          },
+          folder(name) {
+            expect(name).to.be.a("string");
+            return Promise.resolve();
+          },
+        })
+      )
+      .then(() => {
+        return unreachable();
+      })
+      .catch((e) => {
+        expect(e).to.be.an("error").with.property("message").include("file");
+        done();
+      });
+  });
 
   it('should dumping an array object that contains 4 files', done => {
     const workbook = new Workbook();


### PR DESCRIPTION
This pr implements `Topic.image` for the browser.

- Add the `updateManifestMetadata` method to `Dumper` with a different function signature from the method on `Zipper`
- Add a naive example

Please let me know if the new `updateManifestMetadata` method is clear, or the documentation requires further improvement.